### PR TITLE
Fix initialization errors

### DIFF
--- a/lua/kagiroi/kagiroi.lua
+++ b/lua/kagiroi/kagiroi.lua
@@ -1,6 +1,5 @@
 -- common dependency for kagiroi lua scripts
 
-local utf8 = require("utf8")
 local Module = {}
 -- @param string utf8
 -- @param i start_pos

--- a/lua/kagiroi/kagiroi_translator.lua
+++ b/lua/kagiroi/kagiroi_translator.lua
@@ -5,7 +5,6 @@
 -- version: 0.1.0
 -- author: kuroame
 
-local utf8 = require("utf8")
 local kagiroi = require("kagiroi/kagiroi")
 
 local hiragana_node = {

--- a/lua/kagiroi/kagiroi_viterbi.lua
+++ b/lua/kagiroi/kagiroi_viterbi.lua
@@ -6,7 +6,6 @@
 -- version: 0.1.0
 -- author: kuroame
 
-local utf8 = require("utf8")
 local kagiroi = require("kagiroi/kagiroi")
 local Module = {
     kagiroi_dict = require("kagiroi/kagiroi_dict"),


### PR DESCRIPTION
librime-lua (with lua >= 5.3) 里 utf8 总是可用的：

- https://github.com/hchunhui/librime-lua/blob/b86b895/src/lib/lua.cc#L225
- https://github.com/hchunhui/librime-lua/blob/115e000/lua5.4/linit.c#L61

相反，如果手动加载反而会出错：

`kagiroi_viterbi.lua:9: module 'utf8' not found`