### PR TITLE
Viterbi overhaul, 促音 improvements, dummy candidates

### DIFF
--- a/kagiroi.schema.yaml
+++ b/kagiroi.schema.yaml
@@ -74,6 +74,7 @@ editor:
     Return: commit_script_text
 
 key_binder:
+  import_preset: default
   bindings:
     __patch:
       - kagiroi:/key_bindings/paging_with_minus_equal

--- a/kagiroi.yaml
+++ b/kagiroi.yaml
@@ -19,7 +19,7 @@ algebra:
       # 例：xa→la、xya→lya、xtsu→ltsu など
       - derive/^(;?)x([a-z]{1,3})$/$1l$2/
       # 促音のマーク「;」の転換
-      - xform/^;([a-z])(.+)$/$1$1$2/
+      - xform/^;([a-z])(.*)$/$1$1$2/
       # 撥音「ん」を「nn」で入力可能
       - derive/^n$/nn/
       # -を「q」で入力可能

--- a/kagiroi_kana.dict.yaml
+++ b/kagiroi_kana.dict.yaml
@@ -28,6 +28,7 @@ columns:
 ゕ	xka
 ゖ	xke
 っ	xtu
+っ	x
 ー	-
 あ	a
 い	i
@@ -229,6 +230,25 @@ columns:
 ふょ	fyo
 
 # sokuon
+っk	;k
+っc	;c
+っg	;g
+っh	;h
+っj	;j
+っt	;t
+っf	;f
+っw	;w
+っr	;r
+っz	;z
+っs	;s
+っv	;v
+っl	;l
+っt	;t
+っd	;d
+っb	;b
+っp	;p
+っm	;m
+っy	;y
 っゔ	;vu
 っか	;ka
 っき	;ki

--- a/lua/kagiroi/kagiroi_translator.lua
+++ b/lua/kagiroi/kagiroi_translator.lua
@@ -125,7 +125,7 @@ function Top.init(env)
         )
         return math.floor(cost)
     end
-    env.userdict = function(input)
+    env.query_userdict = function(input)
         env.mem:user_lookup(input .. " \t", true)
         local next_func, self = env.mem:iter_user()
         return function()
@@ -154,7 +154,8 @@ function Top.init(env)
             end
         end
     end
-    viterbi.init(env)
+    viterbi.init()
+    viterbi.query_userdict = env.query_userdict
     env.hira2kata_halfwidth_opencc = Opencc("kagiroi_h2kh.json")
     env.mem = Memory(env.engine, Schema('kagiroi'))
 
@@ -196,6 +197,7 @@ function Top.init(env)
                 save_phrase(dictentry)
             end
         end
+        viterbi.clear()
     end)
     env.delete_notifier = env.engine.context.delete_notifier:connect(function(ctx)
         viterbi.clear()

--- a/lua/kagiroi/kagiroi_translator.lua
+++ b/lua/kagiroi/kagiroi_translator.lua
@@ -112,6 +112,7 @@ function Top.init(env)
     env.roma2hira_xlator = Component.Translator(env.engine, Schema('kagiroi_kana'), "translator", "script_translator")
     env.pseudo_xlator = Component.Translator(env.engine, Schema('kagiroi'), "translator", "script_translator")
     env.hira2kata_opencc = Opencc("kagiroi_h2k.json")
+    viterbi.set_hira2kata_opencc(env.hira2kata_opencc)
     env.hira2kata_halfwidth_opencc = Opencc("kagiroi_h2kh.json")
     env.mem = Memory(env.engine, Schema('kagiroi'))
 
@@ -244,13 +245,10 @@ function Top.henkan(hiragana_cand, env)
     end
     local hiragana_text = hiragana_cand.text
     viterbi.analyze(hiragana_text)
-    -- firstly, find a best match for the whole input
+    -- first, find a best match for the whole input
     local best_sentence = viterbi.best()
     yield(Top.lex2cand(hiragana_cand, best_sentence, env, ""))
-    -- secondly, send a "contextual" phrase candidate
-    local prefix = best_sentence.prefix
-    yield(Top.lex2cand(hiragana_cand, prefix, env, ""))
-    -- finally, find the best n matches for the input prefix
+    -- then, find the best n matches for the input prefix
     local best_n = viterbi.best_n_prefix(hiragana_text, -1)
     while true do
         local phrase = best_n()

--- a/lua/kagiroi/kagiroi_translator.lua
+++ b/lua/kagiroi/kagiroi_translator.lua
@@ -245,7 +245,9 @@ function Top.henkan(hiragana_cand, env)
     viterbi.analyze(hiragana_text)
     -- first, find a best match for the whole input
     local best_sentence = viterbi.best()
-    yield(Top.lex2cand(hiragana_cand, best_sentence, env, ""))
+    if best_sentence then
+        yield(Top.lex2cand(hiragana_cand, best_sentence, env, ""))
+    end
     -- then, find the best n matches for the input prefix
     local best_n = viterbi.best_n_prefix(hiragana_text, -1)
     while true do

--- a/lua/kagiroi/kagiroi_translator.lua
+++ b/lua/kagiroi/kagiroi_translator.lua
@@ -242,7 +242,7 @@ function Top.henkan(hiragana_cand, env)
         return
     end
     local hiragana_text = hiragana_cand.text
-    viterbi.analyze(hiragana_text)
+    viterbi.analyze(Top.trim_ending_letter(hiragana_text))
     -- first, find a best match for the whole input
     local best_sentence = viterbi.best()
     if best_sentence then
@@ -354,6 +354,15 @@ function Top.find_end(h_preedit, h_start, h_end, syllable_num)
         return n - syllable_num + h_start
     else
         return h_end
+    end
+end
+
+function Top.trim_ending_letter(hiragana_text)
+    -- if text ends like っx, x is a letter, trim the last character
+    if string.match(hiragana_text, "っ[a-z]$") then
+        return kagiroi.utf8_sub(hiragana_text, 1, -2)
+    else
+        return hiragana_text
     end
 end
 

--- a/lua/kagiroi/kagiroi_viterbi.lua
+++ b/lua/kagiroi/kagiroi_viterbi.lua
@@ -9,6 +9,7 @@
 local kagiroi = require("kagiroi/kagiroi")
 local Module = {
     kagiroi_dict = require("kagiroi/kagiroi_dict"),
+    hira2kata_opencc = Opencc("kagiroi_h2k.json"),
     lattice = {}, -- lattice for viterbi algorithm
     max_word_length = 15,
     lookup_cache = {},
@@ -264,15 +265,14 @@ function Module.init(env)
     Module.kagiroi_dict.load()
     Module.lattice = {}
     Module.lookup_cache = {}
-    Module.query_userdict = env.userdict
-    Module.hira2kata_opencc = env.hira2kata_opencc
+    Module.query_userdict = function(surface)
+        return nil
+    end
 end
 
 function Module.fini()
     Module.lattice = {}
     Module.lookup_cache = {}
-    Module.query_userdict = nil
-    Module.hira2kata_opencc = nil
     Module.kagiroi_dict.release()
 end
 

--- a/lua/kagiroi/kagiroi_viterbi.lua
+++ b/lua/kagiroi/kagiroi_viterbi.lua
@@ -201,8 +201,8 @@ function Module.best()
     while cur_node and cur_node.type ~= "eos" do
         candidate = candidate .. cur_node.candidate
         surface = surface .. cur_node.surface
-        cur_node = Module._pre_node(cur_node)
         right_id = cur_node.right_id
+        cur_node = Module._pre_node(cur_node)
     end
     return {
         surface = surface,

--- a/lua/kagiroi/kagiroi_viterbi.lua
+++ b/lua/kagiroi/kagiroi_viterbi.lua
@@ -124,8 +124,9 @@ function Module.analyze(input)
     -- set the eos nodes
     local eos = Node:new(0, 0, 0, "", "", "eos")
     Module.lattice[input_len_utf8 + 1][1] = eos
-    -- mark if the column has any nodes
-    local valid_col = 1 << input_len_utf8
+    -- mark if the column has any nodes 
+    local valid_col = {}
+    valid_col[input_len_utf8 + 1] = true  -- eos column is valid
     -- i: start position of the surface
     -- j: end position of the surface
     for j = input_len_utf8, 1, -1 do
@@ -134,7 +135,7 @@ function Module.analyze(input)
         -- check if there are any nodes that start at j + 1
         -- if not, nodes end at j cannot be connected to this lattice
         -- so we can skip this iteration
-        if valid_col & (1 << j) == 0 then
+        if not valid_col[j + 1] then
             goto continue
         end
         local max_start = math.max(1, j - Module.max_word_length + 1)
@@ -144,7 +145,7 @@ function Module.analyze(input)
             if iter then
                 for lex in iter do
                     -- mark this column as valid, so that we can search nodes that end at i-1 in the next iteration
-                    valid_col = valid_col | (1 << i - 1)
+                    valid_col[i] = true
                     local node = Node:new_from_lex(lex)
                     -- try to connect to the best node that start at j + 1
                     node.prev_index_col = j + 1

--- a/lua/kagiroi/kagiroi_viterbi.lua
+++ b/lua/kagiroi/kagiroi_viterbi.lua
@@ -3,451 +3,69 @@
 -- to offer contextual candidates.
 
 -- license: GPLv3
--- version: 0.1.0
+-- version: 0.2.0
 -- author: kuroame
 
 local kagiroi = require("kagiroi/kagiroi")
 local Module = {
     kagiroi_dict = require("kagiroi/kagiroi_dict"),
-    lattice = nil
+    lattice = {}, -- lattice for viterbi algorithm
 }
 
-local Node = {
-    prev = nil, -- previous node
-    left_id, -- left id of the node, from lex
-    right_id, -- right id of the node, from lex
-    cost, -- cost of the node, should = prev.cost + matrix(prev.right_id, left_id) + wcost(from lex)
-    surface, -- surface of the node, from lex
-    candidate, -- candidate of the node, from lex
-    bnext_iter, -- iterator of the next node with the same begin position
-    -- _bnext, -- cached next node with the same begin position
-    enext_iter -- iterator of the next node with the same end position
-}
+local Node = {}
 
+-- create a new node
+-- @param left_id int
+-- @param right_id int
+-- @param cost float
+-- @param surface string
 function Node:new(left_id, right_id, cost, surface, candidate, type)
     local o = {}
     setmetatable(o, self)
     self.__index = self
-    o.left_id = left_id
-    o.right_id = right_id
-    o.cost = cost
-    o.surface = surface
-    o.candidate = candidate
-    o.type = type
-    o.bnext_iter = function()
-        return nil
-    end
-    o.enext_iter = function()
-        return nil
-    end
+    o.prev_index_col = 0 -- previous node column
+    o.prev_index_row = 0 -- previous node row
+    o.left_id = left_id -- left id of the node, from lex
+    o.right_id = right_id -- right id of the node, from lex
+    o.cost = cost -- cost of the node, should = prev.cost + matrix(prev.left_id, right_id) + wcost(from lex)
+    o.surface = surface -- surface of the node, from lex
+    o.candidate = candidate -- candidate of the node, from lex
+    o.type = type -- type of the node: dummy, lex, bos(begin of sentence), eos(end of sentence)
     return o
 end
 
-function Node:set_lazy_bnext(next_generator)
-    self.bnext_iter = function()
-        if not self._bnext then
-            self._bnext = next_generator()
-        end
-        return self._bnext
-    end
-    return self
-end
-
+-- create a new node from a lex entry
+-- @param lex table
+-- @return Node
 function Node:new_from_lex(lex)
     return Node:new(lex.left_id, lex.right_id, lex.cost, lex.surface, lex.candidate, "lex")
 end
 
-function Node:to_string()
-    return string.format("Node{surface='%s', candidate='%s', cost=%d, left_id=%d, right_id=%d, type='%s'}",
-        self.surface, self.candidate, self.cost, self.left_id, self.right_id, self.type)
-end
+-- ----------------------------
+-- Private Functions of Module
+-- ----------------------------
 
-local Lattice = {
-    bos_node, -- begin of sentence node
-    eos_node, -- end of sentence node
-    begin_nodes = {}, -- nodes that begin at i
-    begin_nodes_rear = {}, -- the rear node of begin_nodes
-    -- the rear node of begin_nodes section,
-    -- section means a group of nodes of same surface_len
-    -- format: begin_nodes_section_rear[pos][end_pos]
-    begin_nodes_section_rear = {},
-    -- nodes that start at 1
-    -- format:prefix_nodes[surface_len]
-    prefix_nodes = {},
-    end_nodes = {}, -- nodes that end at i
-    -- best previous node and cost(ends at i) 
-    -- for nodes that begin at i with left_id j
-    -- format: best_prev_node_cost[i][j]
-    best_prev_node_cost = {},
-    input = "", -- input string
-    input_len_in_utf8 = 0
-}
-
-function Lattice:new()
-    local o = {}
-    setmetatable(o, self)
-    self.__index = self
-    o.bos_node = Node:new(0, 0, 0, "", "", "bos")
-    o.eos_node = Node:new(0, 0, 0, "", "", "eos")
-    o.end_nodes[1] = o.bos_node
-    return o
-end
-
--- push a utf8 char into the lattice
-function Lattice:push(uchar)
-    self.input = self.input .. uchar
-    self.input_len_in_utf8 = self.input_len_in_utf8 + 1
-    for i = 1, self.input_len_in_utf8 do
-        -- lookup the lexicon for possible nodes that begin at i, and update the begin_nodes
-        self:lookup(i)
-        -- connect the nodes
-        self:connect(i)
-    end
-end
-
--- pop the last utf8 char from the lattice
-function Lattice:pop()
-    -- first, discard the nodes that end at self.input_len_in_utf8 + 1
-    self.end_nodes[self.input_len_in_utf8 + 1] = nil
-    -- then, iterate all begin nodes, and discard nodes that end at self.input_len_in_utf8 + 1
-    for i = 1, self.input_len_in_utf8 do
-        local section_rear = self.begin_nodes_section_rear[i][self.input_len_in_utf8]
-        if section_rear then
-            section_rear.bnext_iter = nil
-            self.begin_nodes_rear[i] = section_rear
-        end
-    end
-    self.input = kagiroi.utf8_sub(self.input, 1, -2)
-    self.best_prev_node_cost[self.input_len_in_utf8 + 1] = nil
-    self.begin_nodes_rear[self.input_len_in_utf8] = nil
-    self.begin_nodes[self.input_len_in_utf8] = nil
-    self.prefix_nodes[self.input_len_in_utf8] = nil
-    self.input_len_in_utf8 = self.input_len_in_utf8 - 1
-end
-
-function Lattice:rebuild(input)
-    self:clear()
-    if input then
-        self:analyze(input)
-    end
-end
-
-function Lattice:clear()
-    self.begin_nodes = {}
-    self.begin_nodes_rear = {}
-    self.begin_nodes_section_rear = {}
-    self.prefix_nodes = {}
-    self.end_nodes = {}
-    self.best_prev_node_cost = {}
-    self.input = ""
-    self.input_len_in_utf8 = 0
-    self.bos_node = Node:new(0, 0, 0, "", "", "bos")
-    self.eos_node = Node:new(0, 0, 0, "", "", "eos")
-    self.end_nodes[1] = self.bos_node
-end
-
-function Lattice:analyze(input)
-    -- clear the lattice if it is a new input
-    if utf8.len(input) == 1 or self.input == "" then
-        self:clear()
-    end
-    -- first we need to figure out the common prefix of input and self.input
-    -- len of remaining part of the self.input should be the times we need to pop
-    -- then we push every utf8 char into our Lattice
-
-    -- strategy: when the common prefix is less than the half of the #input, consider rebuilding the lattice TODO
-
-    -- log.info("input: " .. input .. " self.input: " .. self.input)
-    local common_prefix, new_input_remaining, old_input_remaining = kagiroi.utf8_common_prefix(input, self.input)
-    -- log.info("common_prefix: " .. common_prefix.." \tnew_input_remaining: " .. new_input_remaining..
-    --     "\told_input_remaining: " .. old_input_remaining)
-    local old_input_remaining_len = utf8.len(old_input_remaining)
-
-    -- reset the eos
-    self.begin_nodes[self.input_len_in_utf8 + 1] = nil
-    -- self.eos_node.prev = nil
-    while old_input_remaining_len > 0 do
-        -- log.info("------------------------------------------------------------")
-        -- log.info("poping ".. self.input_len_in_utf8)
-        self:pop()
-        old_input_remaining_len = old_input_remaining_len - 1
-    end
-
-    for uchar in kagiroi.utf8_char_iter(new_input_remaining) do
-        -- log.info("------------------------------------------------------------")
-        -- log.info("pushing: " .. uchar)
-        self:push(uchar)
-    end
-
-    -- connect eos node to our lattice
-    self.begin_nodes[self.input_len_in_utf8 + 1] = self.eos_node
-    self:connect(self.input_len_in_utf8 + 1)
-end
-
--- lookup the lexicon/user_dic for possible nodes that begin at pos, end at len(self.input)
--- then update the self.begin_nodes[pos]
-function Lattice:lookup(pos)
-    local surface = kagiroi.utf8_sub(self.input, pos)
-    local surface_len = utf8.len(surface)
-    -- log.info("querying surface: " .. surface)
+-- lookup the lexicon/user_dic entry for the surface
+-- @param surface string
+-- @return iterator of entries
+function Module._lookup(surface)
     local lex_iter = Module.kagiroi_dict.query_lex(surface, false)
     local userdict_iter = Module.query_userdict(surface)
-    local word_iter = Module._merge_iter(lex_iter, userdict_iter)
-    -- SPECIAL CASE: if surface_len = 1, echo this surface to avoid empty lattice
-    if surface_len == 1 then
-        local emitted = false
-        word_iter = Module._merge_iter(word_iter, function()
-            if not emitted then
-                emitted = true
-                return {
-                    candidate = surface,
-                    surface = surface,
-                    cost = math.huge,
-                    left_id = -2,
-                    right_id = -2
-                }
-            end
-        end)
-    end
-    local function bnext_iter()
-        local lex = word_iter()
-        if lex then
-            -- log.info("found lex: " .. lex.candidate .. " for surface: " .. lex.surface)
-            return Node:new_from_lex(lex):set_lazy_bnext(bnext_iter)
-        else
-            return nil
-        end
-    end
-    -- if there are already begin nodes at pos, append the new nodes to the end
-    if self.begin_nodes[pos] then
-        -- notice that begin_nodes_rear is maintained in connect function
-        local rear_node = self.begin_nodes_rear[pos]
-        -- log.info("appending new nodes to the rear node: " .. rear_node.candidate .. "|" .. rear_node.type.. " at pos: " .. pos)
-        rear_node.bnext_iter = bnext_iter
-    else
-        local node = bnext_iter()
-        -- log.info("first begin node at pos: " .. pos .. " is " .. node.candidate .. "|" .. node.type)
-        self.begin_nodes[pos] = node
-    end
+    return Module._merge_iter(lex_iter, userdict_iter)
 end
 
--- connect the nodes that begin at pos, updating cost, prev, and end_nodes
-function Lattice:connect(pos)
-    -- log.info("connecting pos: " .. pos)
-    -- iterate from the rear node of begin_nodes
-    local rear_node = self.begin_nodes_rear[pos]
-    local cur_node = nil
-    -- if not rear node recorded, which means it is a new linkedlist
-    -- we need to iterate from the beginning
-    if not rear_node then
-        cur_node = self.begin_nodes[pos]
-    else
-        -- log.info("rear node found at pos: " .. pos .. " is " .. rear_node.candidate .. "|" .. rear_node.type)
-        cur_node = rear_node.bnext_iter()
-    end
 
-    while cur_node do
-        -- log.info("connecting cur_node: " .. cur_node.candidate .. "|" .. cur_node.type)
-        -- find a best previous node for current node
-        local best_prev_node = nil
-        local best_cost = math.huge
-
-        -- check if there's already a best previous node recorded
-        if self.best_prev_node_cost[pos] and self.best_prev_node_cost[pos][cur_node.left_id] then
-            -- log.info("cached best_prev_node_cost found at pos: " .. pos .. " for left_id: " .. cur_node.left_id.. " is " .. self.best_prev_node_cost[pos][cur_node.left_id].node.candidate .. "|" .. self.best_prev_node_cost[pos][cur_node.left_id].node.type)
-            local best_node_cost = self.best_prev_node_cost[pos][cur_node.left_id]
-            best_prev_node = best_node_cost.node
-            -- best_node_cost.cost = best_prev_node.cost + trans_cost
-            -- recorded to save an extra matrix query
-            best_cost = best_node_cost.cost + cur_node.cost
-        end
-
-        -- if not, we need to find the best previous node from the end_nodes at pos
-        if not best_prev_node then
-            -- iterate the possible prev node(nodes that end at pos) from the beginning of the linkedlist
-            local prev_node = self.end_nodes[pos]
-            if not prev_node then
-                -- log.info("no previous node found at pos: " .. pos)
-                -- if no previous node found, then this cur_node is unlinkable
-                -- we need to move to the next node
-                goto continue
-            end
-            best_prev_node = prev_node
-            while prev_node do
-                -- log.info("iterating prev_node: " .. prev_node.candidate .. "|" .. prev_node.type)
-                -- just for debugging, this should not happen
-                if prev_node.type == "eos" then
-                    log.error("eos node found in the middle of the lattice")
-                end
-                -- query the transition cost
-                local trans_cost = Module.kagiroi_dict.query_matrix(prev_node.right_id, cur_node.left_id)
-                -- calculate the accumulated cost
-                local acost = prev_node.cost + trans_cost + cur_node.cost
-                -- update best cost and best prev node if needed
-                if acost < best_cost then
-                    best_cost = acost
-                    best_prev_node = prev_node
-                end
-                -- move to the next prev node
-                prev_node = prev_node.enext_iter()
-            end
-        end
-
-        -- update the best_prev_node_cost
-        if not self.best_prev_node_cost[pos] then
-            self.best_prev_node_cost[pos] = {}
-        end
-        self.best_prev_node_cost[pos][cur_node.left_id] = {
-            node = best_prev_node,
-            cost = best_cost - cur_node.cost
-        }
-
-        -- update the node
-        cur_node.prev = best_prev_node
-        cur_node.cost = best_cost
-
-        -- SPECIAL CASE: if best_prev_node is bos Node
-        -- need to maintain a list for best_n_phrase to iterate
-        if best_prev_node.type == "bos" then
-            local surface_len = utf8.len(cur_node.surface)
-            if not self.prefix_nodes[surface_len] then
-                self.prefix_nodes[surface_len] = {}
-            end
-            kagiroi.insert_sorted(self.prefix_nodes[surface_len], cur_node, function(a, b)
-                return a.cost < b.cost
-            end)
-        end
-
-        -- log.info("connect prev node to cur_node: " .. best_prev_node.candidate .. "|" .. best_prev_node.type .. " -> " ..
-        --           cur_node.candidate .. "|" .. cur_node.type)
-
-        -- update end_nodes, best_prev_node_cost,
-        -- this lex type check is to ensure the eos node won't be considered as end node,
-        -- since no need to append any node to the eos node
-        if cur_node.type == "lex" then
-            -- update the end_nodes
-            local current_end = self.end_nodes[self.input_len_in_utf8 + 1]
-            cur_node.enext_iter = function()
-                return current_end
-            end
-            self.end_nodes[self.input_len_in_utf8 + 1] = cur_node
-            -- log.info("update end_nodes at pos: " .. self.input_len_in_utf8 + 1 .. " with node: " .. cur_node.candidate.. "|" .. cur_node.type)
-        end
-
-        ::continue::
-        local next_node = cur_node.bnext_iter()
-        if not next_node then
-            -- if no next node found, then this cur_node is the rear node
-            -- we need to record it
-            if cur_node.type == "lex" then
-                self.begin_nodes_rear[pos] = cur_node
-                if not self.begin_nodes_section_rear[pos] then
-                    self.begin_nodes_section_rear[pos] = {}
-                end
-                self.begin_nodes_section_rear[pos][self.input_len_in_utf8 + 1] = cur_node
-                -- log.info("recorded rear node at pos: " .. pos .. " is " .. cur_node.candidate .. "|" .. cur_node.type)
-            end
-            -- log.info("no next node found, break, cur_node: " .. cur_node.candidate .. "|" .. cur_node.type)
-            break
-        end
-        -- move to the next node
-        cur_node = next_node
-    end
+-- get the previous node of the node
+-- @param node Node
+-- @return Node
+function Module._pre_node(node)
+    return Module.lattice[node.prev_index_col][node.prev_index_row]
 end
 
--- get the best sentence
-function Lattice:best_sentence()
-    local prev = self.eos_node.prev
-    if not prev then
-        self:clear()
-        error("eos node not connected!")
-    end
-    local candidate = ""
-    local surface = ""
-    local prefix = nil
-    local left_id = prev.left_id
-    local right_id = prev.right_id
-    while prev do
-        candidate = prev.candidate .. candidate
-        surface = prev.surface .. surface
-        if prev.prev and prev.prev.type == "bos" then
-            prefix = prev
-            break
-        end
-        prev = prev.prev
-        left_id = prev.left_id
-    end
-    return {
-        surface = surface,
-        candidate = candidate,
-        cost = self.eos_node.cost,
-        prefix = prev,
-        left_id = left_id,
-        right_id = right_id
-    }
-end
-
--- get the best n phrases starting from the beginning of input
--- returns an iterator that yields nodes in the ascending order of lengh of the surface, then cost
-function Lattice:best_n_phrase(n)
-    local cur_len = self.input_len_in_utf8
-    local current_index = 1
-    return function()
-        while cur_len > 0 do
-            local cur_nodes = self.prefix_nodes[cur_len]
-            if cur_nodes and #cur_nodes > 0 then
-                if current_index <= #cur_nodes then
-                    local node = cur_nodes[current_index]
-                    current_index = current_index + 1
-                    return node
-                else
-                    cur_len = cur_len - 1
-                    current_index = 1
-                end
-            else
-                cur_len = cur_len - 1
-                current_index = 1
-            end
-        end
-        return nil
-    end
-end
-
-function Module.init()
-    Module.kagiroi_dict.load()
-    Module.lattice = Lattice:new()
-    Module.query_userdict = function(i)
-        return function()
-            return nil
-        end
-    end
-end
-
-function Module.fini()
-    Module.lattice:clear()
-    Module.kagiroi_dict.release()
-end
-
-function Module.analyze(input)
-    Module.lattice:analyze(input)
-end
-
-function Module.clear()
-    Module.lattice:clear()
-end
-
-function Module.best()
-    return Module.lattice:best_sentence()
-end
-
-function Module.best_n_prefix(n)
-    return Module.lattice:best_n_phrase(n)
-end
-
-function Module.register_userdict(userdict)
-    Module.query_userdict = userdict
-end
-
+-- merge two iterators
+-- @param iter1 iterator
+-- @param iter2 iterator
+-- @return iterator
 function Module._merge_iter(iter1, iter2)
     local current_iter = iter1
     return function()
@@ -464,6 +82,167 @@ function Module._merge_iter(iter1, iter2)
             end
         end
     end
+end
+
+-- ----------------------------
+-- Public Functions of Module
+-- ----------------------------
+
+-- build the lattice for the input
+-- column of lattice: start position of the surface
+-- @param input string
+function Module.analyze(input)
+    local input_len_utf8 = utf8.len(input)
+    
+    -- initialize lattice columns as empty tables
+    for i = 1, input_len_utf8 + 1 do
+        Module.lattice[i] = {}
+    end
+    
+    -- set the eos nodes
+    local eos = Node:new(0, 0, 0, "", "", "eos")
+    Module.lattice[input_len_utf8 + 1][1] = eos
+    -- mark if the column has any nodes
+    local valid_col = 1 << input_len_utf8
+    -- i: start position of the surface
+    -- j: end position of the surface
+    for j = input_len_utf8, 1, -1 do
+        -- search nodes that end at j
+
+        -- check if there are any nodes that start at j + 1
+        -- if not, nodes end at j cannot be connected to this lattice
+        -- so we can skip this iteration
+        if valid_col & (1 << j) == 0 then
+            goto continue
+        end
+        for i = 1, j do
+            local surface = kagiroi.utf8_sub(input, i, j)
+            local iter = Module._lookup(surface)
+            if iter then
+                for lex in iter do
+                    -- mark this column as valid, so that we can search nodes that end at i-1 in the next iteration
+                    valid_col = valid_col | (1 << i - 1)
+                    local node = Node:new_from_lex(lex)
+                    table.insert(Module.lattice[i], node)
+                    -- try to connect to the best node that start at j + 1
+                    node.prev_index_col = j + 1
+                    local open_nodes = Module.lattice[node.prev_index_col]
+                    -- evaluate open nodes
+                    node.cost = math.huge
+                    -- k: row index of the open node
+                    for k, open_node in ipairs(open_nodes) do
+                        local cost = open_node.cost +
+                            Module.kagiroi_dict.query_matrix(lex.right_id, open_node.left_id) +
+                            lex.cost
+                        if cost < node.cost then
+                            node.cost = cost
+                            node.prev_index_row = k
+                        end
+                    end
+                end
+            end
+        end
+        ::continue::
+    end
+
+    -- sort the nodes in lattice[1] by cost
+    table.sort(Module.lattice[1], function(a, b)
+        return a.cost + Module.kagiroi_dict.query_matrix(eos.right_id, a.left_id) <
+            b.cost + Module.kagiroi_dict.query_matrix(eos.right_id, b.left_id)
+    end)
+end
+
+-- generate best candidate for the input
+-- @return iterator of nbest list
+function Module.best()
+    local best_node = Module.lattice[1][1]
+    if not best_node then
+        return {
+            surface = "",
+            candidate = "",
+            cost = math.huge,
+            left_id = 0,
+            right_id = 0
+        }
+    end
+    local candidate = ""
+    local surface = ""
+    local left_id = best_node.left_id
+    local right_id = best_node.right_id
+    local cur_node = best_node
+    while cur_node and cur_node.type ~= "eos" do
+        candidate = candidate .. cur_node.candidate
+        surface = surface .. cur_node.surface
+        left_id = cur_node.left_id
+        cur_node = Module._pre_node(cur_node)
+        right_id = cur_node.right_id
+    end
+    return {
+        surface = surface,
+        candidate = candidate,
+        cost = best_node.cost,
+        left_id = left_id,
+        right_id = right_id
+    }
+end
+
+-- generate the nbest list for the prefix
+-- @return iterator of nbest list
+function Module.best_n_prefix()
+    local current_index = 1
+    local current_dummy_index = 1
+    local high_quality_count = 7
+    local high_quality_cost = 46040
+    local is_dummy_node_emitted = false
+    local surface = {}
+    local max_dummy_surface_len = 4
+    return function()
+        while current_index <= #Module.lattice[1] do
+            local best_n_node = Module.lattice[1][current_index]
+            if (utf8.len(best_n_node.surface) < max_dummy_surface_len) then
+                table.insert(surface, best_n_node.surface)
+                table.insert(surface, Module.hira2kata_opencc:convert(best_n_node.surface))
+            end
+            if not is_dummy_node_emitted and ((best_n_node.cost >= high_quality_cost or high_quality_count <= 0) or current_index >= #Module.lattice[1]) then
+                is_dummy_node_emitted = true
+                while current_dummy_index <= #surface do
+                    current_dummy_index = current_dummy_index + 1
+                    return Node:new(0, 0, 46041, surface[current_dummy_index], surface[current_dummy_index], "dummy")
+                end
+            end
+            current_index = current_index + 1
+            high_quality_count = high_quality_count - 1
+            return best_n_node
+        end
+    end
+end
+
+function Module.register_userdict(userdict)
+    Module.query_userdict = userdict
+end
+
+function Module.set_hira2kata_opencc(hira2kata_opencc)
+    Module.hira2kata_opencc = hira2kata_opencc
+end
+
+function Module.clear()
+    Module.lattice = {}
+end
+
+function Module.init()
+    Module.kagiroi_dict.load()
+    Module.lattice = {}
+    Module.query_userdict = function(i)
+        return function()
+            return nil
+        end
+    end
+end
+
+function Module.fini()
+    Module.lattice = {}
+    Module.kagiroi_dict.release()
+    Module.hira2kata_opencc = nil
 end
 
 return Module

--- a/tests/kagiroi.test.yaml
+++ b/tests/kagiroi.test.yaml
@@ -33,7 +33,7 @@ deploy:
         assert: cand[1].text == "水平線が光る朝にあなたの希望が崩れ落ちて"
       
       # partial selection
-      - send: 'daisukidattakotomo32241'
+      - send: 'daisukidattakotomo32231'
         assert: commit == "だいすきだった事も"
 
   nohenkan:


### PR DESCRIPTION
-  Refactored Viterbi algorithm for better candidate ranking
-  Added support for typing 'x' to input standalone 促音 (っ)
-  Fixed double-letter patterns (e.g., 'tt') for more natural 促音 conversion
-  Introduced dummy candidates to ensure katakana candidates are always available (#6 )